### PR TITLE
Add support for mysql2

### DIFF
--- a/packages/xc-data-mapper/lib/DbFactory.js
+++ b/packages/xc-data-mapper/lib/DbFactory.js
@@ -4,7 +4,7 @@ class DbFactory {
   static create(connectionConfig) {
     if (connectionConfig.client === "sqlite3") {
       return knex(connectionConfig.connection)
-    } else if (['mysql', 'pg', 'mssql']) {
+    } else if (['mysql', 'mysql2', 'pg', 'mssql']) {
       return knex(connectionConfig)
     }
     throw new Error("Database not supported");

--- a/packages/xc-data-mapper/package.json
+++ b/packages/xc-data-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xc-data-mapper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Map database tables with a driver",
   "author": "oof1lab <oof1lab@gmail.com>",
   "homepage": "https://xgene.cloud",
@@ -37,6 +37,7 @@
     "glob": "^7.1.6",
     "mocha": "^7.0.1",
     "mysql": "^2.18.1",
+    "mysql2": "^2.1.0",
     "jsdoc-to-markdown": "^5.0.3"
   }
 }

--- a/packages/xc-migrator/lib/SqlClient/lib/SqlClientFactory.js
+++ b/packages/xc-migrator/lib/SqlClient/lib/SqlClientFactory.js
@@ -4,14 +4,13 @@ const SqliteClient = require("./sqlite/SqliteClient");
 const PgClient = require("./pg/PgClient");
 
 class SqlClientFactory {
-  
+
   static create(connectionConfig) {
     connectionConfig.meta = connectionConfig.meta || {};
     connectionConfig.meta.dbtype = connectionConfig.meta.dbtype || "";
-    if (connectionConfig.client === "mysql") {
+    if (connectionConfig.client === "mysql" || connectionConfig.client === "mysql2") {
       return new MySqlClient(connectionConfig);
     }
-
     if (connectionConfig.client === "sqlite3")
       return new SqliteClient(connectionConfig);
     if (connectionConfig.client === "mssql")

--- a/packages/xc-migrator/lib/SqlMigrator/lib/KnexMigrator.js
+++ b/packages/xc-migrator/lib/SqlMigrator/lib/KnexMigrator.js
@@ -207,6 +207,7 @@ class KnexMigrator extends SqlMigrator {
           freshProject = args.projectJson;
         } else {
           switch (args.type) {
+            case "mysql2":
             case "mysql":
               freshProject = require("./templates/mysql.template.js");
               break;

--- a/packages/xc-migrator/lib/SqlMigrator/lib/KnexMigrator.js
+++ b/packages/xc-migrator/lib/SqlMigrator/lib/KnexMigrator.js
@@ -208,6 +208,9 @@ class KnexMigrator extends SqlMigrator {
         } else {
           switch (args.type) {
             case "mysql2":
+              freshProject = require("./templates/mysql2.template.js");
+              break;
+
             case "mysql":
               freshProject = require("./templates/mysql.template.js");
               break;

--- a/packages/xc-migrator/lib/SqlMigrator/lib/SqlMigratorFactory.js
+++ b/packages/xc-migrator/lib/SqlMigrator/lib/SqlMigratorFactory.js
@@ -4,6 +4,7 @@ const KnexMigrator = require("./KnexMigrator");
 class SqlMigratorFactory {
   static create(args) {
     switch (args.client) {
+      case "mysql2":
       case "mysql":
       case "pg":
       case "oracledb":

--- a/packages/xc-migrator/lib/SqlMigrator/lib/templates/mysql2.template.js
+++ b/packages/xc-migrator/lib/SqlMigrator/lib/templates/mysql2.template.js
@@ -1,0 +1,54 @@
+
+const {DOCKER_DB_HOST, DOCKER_DB_PORT} = process.env;
+
+module.exports = {
+  title: "default",
+  envs: {
+    dev: {
+      db: [
+        {
+          client: "mysql2",
+          connection: {
+            host: DOCKER_DB_HOST || "localhost",
+            port: DOCKER_DB_PORT || 3306,
+            user: "root",
+            password: "password",
+            database: "default_dev"
+          },
+          meta: {
+            tableName: "_evolutions",
+            dbAlias: "primary"
+          }
+        }
+      ]
+    },
+    test: {
+      api: {},
+      db: [
+        {
+          client: "mysql2",
+          connection: {
+            host: DOCKER_DB_HOST || "localhost",
+            port: DOCKER_DB_PORT || 3306,
+            user: "root",
+            password: "password",
+            database: "default_test"
+          },
+          meta: {
+            tableName: "_evolutions",
+            dbAlias: "primary"
+          }
+        }
+      ]
+    }
+  },
+  workingEnv: "dev",
+  meta: {
+    version: '0.5',
+    seedsFolder: 'seeds',
+    queriesFolder: 'queries',
+    apisFolder: 'apis',
+    orm: 'sequelize',
+    router: 'express'
+  }
+};

--- a/packages/xc-migrator/package-lock.json
+++ b/packages/xc-migrator/package-lock.json
@@ -188,6 +188,11 @@
         "color-convert": "^1.9.0"
       }
     },
+    "ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -504,6 +509,15 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "requires": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -926,6 +940,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+    },
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -1328,8 +1347,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -1812,6 +1830,14 @@
         }
       }
     },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2284,6 +2310,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -2721,6 +2752,11 @@
         "chalk": "^2.0.1"
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -3057,6 +3093,53 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "mysql2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.1.0.tgz",
+      "integrity": "sha512-9kGVyi930rG2KaHrz3sHwtc6K+GY9d8wWk1XRSYxQiunvGcn4DwuZxOwmK11ftuhhwrYDwGx9Ta4VBwznJn36A==",
+      "requires": {
+        "cardinal": "^2.1.1",
+        "denque": "^1.4.1",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.5.0",
+        "long": "^4.0.0",
+        "lru-cache": "^5.1.1",
+        "named-placeholders": "^1.1.2",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.1"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+          "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "named-placeholders": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
+      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
+      "requires": {
+        "lru-cache": "^4.1.3"
       }
     },
     "nan": {
@@ -4731,6 +4814,14 @@
         "resolve": "^1.1.6"
       }
     },
+    "redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "requires": {
+        "esprima": "~4.0.0"
+      }
+    },
     "reduce-extract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
@@ -4981,6 +5072,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
       "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
       "dev": true
+    },
+    "seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/packages/xc-migrator/package.json
+++ b/packages/xc-migrator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "xc-migrator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SQL based schema migrations or evolutions",
   "main": "index.js",
   "bin": {
     "xcm": "./index.js"
   },
   "scripts": {
-    "test:travis" : "echo \"test travis\"",
+    "test:travis": "echo \"test travis\"",
     "dev": "node index.js -i test",
     "pubilsh": "npm publish .",
     "migration-test": "rm -rf xmigrator.json primary-db secondary-db && DB_TYPE=mysql mocha ./lib/SqlMigratorCli/tests/sql.cli.test.js --exit",
@@ -48,6 +48,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.24.0",
     "mysql": "^2.16.0",
+    "mysql2": "^2.1.0",
     "rmdir": "^1.2.0",
     "sqlite3": "^4.0.6"
   },


### PR DESCRIPTION
First of all, I want to thank you for building such an awesome product. This has helped me save a lot of time 🙂 

This PR adds support for letting the user specify the database client as [mysql2](https://github.com/sidorares/node-mysql2). Knex already has support for mysql2:
![image](https://user-images.githubusercontent.com/10184251/92984390-c749a780-f477-11ea-9ab2-491403da8bba.png)

I'm finding myself needing to use mysql2, because my MySQL server version is >8.0. Apparently the mysql package for Node [doesn't support various aspects of MySQL >8](https://github.com/mysqljs/mysql/issues/2002), and there are multiple unmerged PRs open ([example](https://github.com/mysqljs/mysql/pull/1962), [example](https://github.com/mysqljs/mysql/pull/2327), [example](https://github.com/mysqljs/mysql/pull/2233)). 

mysql2 works perfectly for me.

Please feel free to suggest changes to this PR. Once again, thank you for this excellent and well-built tool!