### PR TITLE
Minimum limit of a request should not be limited to 5.

### DIFF
--- a/packages/xc-data-mapper/lib/BaseModel.js
+++ b/packages/xc-data-mapper/lib/BaseModel.js
@@ -44,7 +44,7 @@ class BaseModelSql {
     this.belongsToRelations = belongsTo;
     this.config = {
       limitMax: 500,
-      limitMin: 5,
+      limitMin: 1,
       limitDefault: 10,
       log: true,
       explain: false,

--- a/packages/xc-data-mapper/lib/sql/BaseModelSql.js
+++ b/packages/xc-data-mapper/lib/sql/BaseModelSql.js
@@ -55,7 +55,7 @@ class BaseModelSql extends BaseModel {
     this.belongsToRelations = belongsTo;
     this.config = {
       limitMax: 500,
-      limitMin: 5,
+      limitMin: 1,
       limitDefault: 10,
       log: true,
       explain: false,


### PR DESCRIPTION
A graphQL query like :
```
query test {
  PersonList( limit: 2 ) {
    id
    name
  }
}
```
should bring back only 2 results, not 5